### PR TITLE
Fix autocompletions loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-zpm - Zsh Plugin Manager
+zpm - Zsh Plugin Manager [![Build Status](https://travis-ci.org/desyncr/zpm.svg)](https://travis-ci.org/desyncr/zpm)
 ===
 
 zpm is a spin off Antigen which aims to provide a lightweight, fast and flexible plugin manager for ZSH.

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -135,6 +135,8 @@
             # If there is no `*.plugin.zsh` file, source *all* the `*.zsh`
             # files.
             for script ($location/*.*sh(N)) { echo "$script" }
+        else
+            echo "$location"
         fi
     fi
 }


### PR DESCRIPTION
Autocompletions were failing to load due a bug in package-source function which caused plugin paths to not be added to 'fpath', thus not being available to autocompletions.
